### PR TITLE
Added support for wrap-around

### DIFF
--- a/keymaps/lisp-paredit.cson
+++ b/keymaps/lisp-paredit.cson
@@ -26,6 +26,7 @@
   'ctrl-alt-down':      'lisp-paredit:splice-forwards'
   'ctrl-alt-s':         'lisp-paredit:splice'
   'ctrl-alt-/':         'lisp-paredit:split'
+  'ctrl-alt-(':         'lisp-paredit:wrap-around'
 
 'atom-text-editor[data-grammar~="clojure"].lisp-paredit-strict,
  atom-text-editor[data-grammar~="lisp"].lisp-paredit-strict,

--- a/lib/edit-commands.coffee
+++ b/lib/edit-commands.coffee
@@ -3,6 +3,9 @@ utils = require "./utils"
 paredit = require "paredit.js"
 
 module.exports =
+  wrapAround: ->
+    edit((ast, src, index, args) -> paredit.editor.wrapAround ast, src, index, '(', ')', args)
+
   slurpBackwards: ->
     edit(paredit.editor.slurpSexp, backward: true)
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -76,6 +76,7 @@ enableParedit = (subs, views) ->
     ["splice-backwards",     edit.spliceBackwards]
     ["splice-forwards",      edit.spliceForwards]
     ["split",                edit.split]
+    ["wrap-around",          edit.wrapAround]
     ["forward-sexp",         nav.forwardSexp]
     ["backward-sexp",        nav.backwardSexp]
     ["up-sexp",              nav.upSexp]

--- a/spec/lisp-paredit-spec.coffee
+++ b/spec/lisp-paredit-spec.coffee
@@ -84,6 +84,8 @@ describe "LispParedit", ->
 
     testCommand "split",                "(a |b c)",             "(a )| (b c)"
 
+    testCommand "wrap-around",          "(a |b c)",             "(a (|b) c)"
+
     testCommand "expand-selection",     "(a (b| c) d)",         "(a (<b> c) d)"
     testCommand "expand-selection",     "(a (<b> c) d)",        "(a (<b c>) d)"
     testCommand "expand-selection",     "(a (<b>\n c) d)",      "(a (<b\n c>) d)"


### PR DESCRIPTION
Hello! 

First of all, I'd like to thank you for your hard work on this very useful Atom package! I share your goal of improving Atom's support for Lisp-like languages. :-)

Coming from Emacs, one of my favorite paredit features was the ability to "wrap around" an expression. Say for instance I have something like "(a |b c)". Wrapping around would yield "(a (|b) c)". Use it all the time.

This pull request adds support for wrap-around to your very nice package. What do you think? Perhaps once cause for concern is that it always uses '(' and ')' and not other types of parens / brackets - not sure if you have any thoughts about that.

Thanks again for your work!

Cheers,
Steve

P.S. I've been developing an atom package myself, [`atom-slime`](https://atom.io/packages/atom-slime). It's in the very early development stages, but aims to make Atom a full-fledged Lisp IDE. With a Lisp process running an unmodified Swank server from the [Slime project](https://common-lisp.net/project/slime/), this package will connect to it, offer a REPL, autocomplete, "go to definition", and more. It's still pretty rough and in development.
