### PR TITLE
Move right in strict mode if applicable

### DIFF
--- a/lib/strict-mode.coffee
+++ b/lib/strict-mode.coffee
@@ -38,8 +38,13 @@ enableEditorStrictMode = (strictSubs, editor, views) ->
           editor.moveLeft()
       closeBrace = closingBraces.some (ch) -> ch == event.text
       if closeBrace
+        p = editor.getCursorBufferPosition()
+        nextCharacter = editor.getTextInBufferRange [[p.row, p.column], [p.row, p.column + 1]]
+        if nextCharacter == event.text
+          editor.moveRight()
+        else
+          views.invalidInput()
         event.cancel()
-        views.invalidInput()
     else
       stack = []
       for c in event.text


### PR DESCRIPTION
Hello!

Thanks again for your hard work on this wonderful Atom package!

One feature I really like about paredit in Emacs is the ability to move the cursor right if a closing brace is inserted, in some circumstances. For example, in strict mode, if the buffer looks like `((|))` and the user types a ')', then the result will be `(()|)` instead of the cursor not moving. 

In other words, this lets you "type over" closing braces even in strict mode. I personally find this feature very useful for editing code, since I can type things like `()` in strict mode without the cursor stopping.

I've put together a pull request implementing this feature. What do you think? If you don't want to make this feature enabled by default, I'd be happy to make it an optional argument controllable through the package preferences.

Thanks!

Cheers,
Steve
