### PR TITLE
Properly dispose of config subscriptions

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -47,7 +47,7 @@ module.exports = LispParedit =
 
     utils.addCommands [["toggle", toggle, 'atom-workspace']], @persistentSubscriptions, @views
 
-    atom.config.observe 'lisp-paredit.enabled', (shouldEnable) =>
+    @persistentSubscriptions.add atom.config.observe 'lisp-paredit.enabled', (shouldEnable) =>
       if shouldEnable
         @subscriptions = new CompositeDisposable
         enableParedit(@subscriptions, @views)
@@ -58,14 +58,14 @@ module.exports = LispParedit =
         disableParedit(@subscriptions, @views)
         strict.disableStrictMode(@strictSubscriptions, @views)
 
-    atom.config.onDidChange 'lisp-paredit.strict', (event) =>
+    @persistentSubscriptions.add atom.config.onDidChange 'lisp-paredit.strict', (event) =>
       if event.newValue and atom.config.get 'lisp-paredit.enabled'
         @strictSubscriptions = new CompositeDisposable
         strict.enableStrictMode(@strictSubscriptions, @views)
       else
         strict.disableStrictMode(@strictSubscriptions, @views)
 
-    atom.config.onDidChange 'lisp-paredit.indentationForms', (event) =>
+    @persistentSubscriptions.add atom.config.onDidChange 'lisp-paredit.indentationForms', (event) =>
       configureParedit()
 
   deactivate: ->
@@ -120,7 +120,7 @@ enableParedit = (subs, views) ->
 observeEditor = (editor, subs, views) ->
   checkSyntax(editor, views)
   subs.add editor.onDidStopChanging ->
-    checkSyntax(editor, views)  
+    checkSyntax(editor, views)
 
 checkSyntax = (editor, views) ->
   path = editor.getPath()


### PR DESCRIPTION
This is an unreported bug, but the fix is just 3 lines:

How to reproduce:
1. Open a lisp file
2. Disable this package
3. Re-enable this package
4. Disable `lisp-paredit.enabled` (I clicked at the status-bar indicator)
5. Re-enable `lisp-paredit.enabled`

If you now try to enter a newline, you enter two.
If you now try to enter an opening bracket, you enter `((|))`.

My fix simply disposes the config subscriptions on `deactivate` by adding them to `persistentSubscriptions`.

Let me know what you think.
