### PR TITLE
Enable keybindings for Racket language

### DIFF
--- a/keymaps/lisp-paredit.cson
+++ b/keymaps/lisp-paredit.cson
@@ -1,6 +1,7 @@
 'atom-text-editor[data-grammar~="clojure"],
  atom-text-editor[data-grammar~="lisp"],
  atom-text-editor[data-grammar~="newlisp"],
+ atom-text-editor[data-grammar~="racket"],
  atom-text-editor[data-grammar~="scheme"]':
   'ctrl-alt-,':         'lisp-paredit:barf-forwards'
   'ctrl-alt-.':         'lisp-paredit:slurp-forwards'
@@ -34,6 +35,7 @@
 'atom-text-editor[data-grammar~="clojure"].lisp-paredit-strict,
  atom-text-editor[data-grammar~="lisp"].lisp-paredit-strict,
  atom-text-editor[data-grammar~="newlisp"].lisp-paredit-strict,
+ atom-text-editor[data-grammar~="racket"].lisp-paredit-strict,
  atom-text-editor[data-grammar~="scheme"].lisp-paredit-strict':
   'backspace':          'lisp-paredit:delete-backwards'
   'ctrl-h':             'lisp-paredit:delete-backwards'


### PR DESCRIPTION
Makes keybindings work with https://github.com/vito/language-racket
