### PR TITLE
Remove deprecated Shadow DOM selector for Atom 1.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/jonspalding/lisp-paredit",
   "license": "MIT",
   "engines": {
-    "atom": ">=0.208.0"
+    "atom": ">=1.13.0"
   },
   "dependencies": {
     "paredit.js": "^0.2.13",

--- a/styles/lisp-paredit.atom-text-editor.less
+++ b/styles/lisp-paredit.atom-text-editor.less
@@ -1,5 +1,5 @@
 @import "ui-variables";
 
-atom-text-editor::shadow .lisp-syntax-error .region {
+atom-text-editor .lisp-syntax-error .region {
   background-color: fade(@background-color-error, 50%) !important;
 }


### PR DESCRIPTION
Shadow DOM selectors have been dropped as of Atom 1.13. Packages and themes still using them are triggering deprecation warnings; this PR fixes that for this package so no deprecations are shown.

@jonspalding Don't forget to release a patch once this is merged. :-)