### PR TITLE
Implement contraction shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ ctrl-left          | backward-sexp
 ctrl-up            | up-sexp
 ctrl-down          | down-sexp
 ctrl-w             | expand-selection
+ctrl-alt-space     | contract-selection
 ctrl-alt-up        | splice-backwards
 ctrl-alt-down      | splice-forwards
 ctrl-alt-s         | splice

--- a/keymaps/lisp-paredit.cson
+++ b/keymaps/lisp-paredit.cson
@@ -20,6 +20,7 @@
   'ctrl-up':            'lisp-paredit:up-sexp'
   'ctrl-down':          'lisp-paredit:down-sexp'
   'ctrl-w':             'lisp-paredit:expand-selection'
+  'ctrl-alt-space':     'lisp-paredit:contract-selection'
 
   'enter':              'lisp-paredit:newline'
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -101,6 +101,7 @@ enableParedit = (subs, views) ->
     ["up-sexp",              nav.upSexp]
     ["down-sexp",            nav.downSexp]
     ["expand-selection",     nav.expandSelection]
+    ["contract-selection",   nav.contractSelection]
     ["indent",               edit.indent]
     ["newline",              edit.newline]
     ["wrap-around-parens",   edit.wrapAroundParens]

--- a/lib/navigation-commands.coffee
+++ b/lib/navigation-commands.coffee
@@ -2,7 +2,7 @@
 utils = require "./utils"
 paredit = require "paredit.js"
 
-expandState = {}
+expandState = {range: null, prev: null}
 
 module.exports =
   forwardSexp: ->
@@ -21,21 +21,22 @@ module.exports =
     startIndex = utils.convertPointToIndex(range.start, editor)
     endIndex = utils.convertPointToIndex(range.end, editor)
 
+    if expandState.range is null
+      expandState.range = range
+
     res = paredit.navigator.sexpRangeExpansion(ast, startIndex, endIndex)
     if res and res.length == 2
       [start, end] = res
       newSelection = new Range(utils.convertIndexToPoint(start, editor), utils.convertIndexToPoint(end, editor))
       editor.setSelectedBufferRange(newSelection)
       expandState = {range: newSelection, prev: expandState}
-      console.log "PREV: ", !!Object.keys(expandState.prev).length
 
   contractSelection: ->
-    if Object.keys(expandState.prev).length
+    if expandState.prev isnt null
       expandState = expandState.prev
       editor = atom.workspace.getActiveTextEditor()
       editor.setSelectedBufferRange(expandState.range)
-      console.log "PREV: ", !!Object.keys(expandState.prev).length
-      
+
 navigate = (fn) ->
   editor = atom.workspace.getActiveTextEditor()
   ast = paredit.parse(editor.getText())

--- a/lib/navigation-commands.coffee
+++ b/lib/navigation-commands.coffee
@@ -2,6 +2,8 @@
 utils = require "./utils"
 paredit = require "paredit.js"
 
+expandState = {}
+
 module.exports =
   forwardSexp: ->
     navigate(paredit.navigator.forwardSexp)
@@ -24,7 +26,16 @@ module.exports =
       [start, end] = res
       newSelection = new Range(utils.convertIndexToPoint(start, editor), utils.convertIndexToPoint(end, editor))
       editor.setSelectedBufferRange(newSelection)
+      expandState = {range: newSelection, prev: expandState}
+      console.log "PREV: ", !!Object.keys(expandState.prev).length
 
+  contractSelection: ->
+    if Object.keys(expandState.prev).length
+      expandState = expandState.prev
+      editor = atom.workspace.getActiveTextEditor()
+      editor.setSelectedBufferRange(expandState.range)
+      console.log "PREV: ", !!Object.keys(expandState.prev).length
+      
 navigate = (fn) ->
   editor = atom.workspace.getActiveTextEditor()
   ast = paredit.parse(editor.getText())

--- a/lib/navigation-commands.coffee
+++ b/lib/navigation-commands.coffee
@@ -21,8 +21,8 @@ module.exports =
     startIndex = utils.convertPointToIndex(range.start, editor)
     endIndex = utils.convertPointToIndex(range.end, editor)
 
-    if expandState.range is null
-      expandState.range = range
+    if expandState.prev is null or range.containsRange(expandState.prev.range) is false
+      expandState = {range: range, prev: null}
 
     res = paredit.navigator.sexpRangeExpansion(ast, startIndex, endIndex)
     if res and res.length == 2
@@ -32,10 +32,12 @@ module.exports =
       expandState = {range: newSelection, prev: expandState}
 
   contractSelection: ->
-    if expandState.prev isnt null
+    editor = atom.workspace.getActiveTextEditor()
+    range = editor.getSelectedBufferRange()
+
+    if expandState.prev and expandState.prev.range and range.containsRange(expandState.prev.range)
+      editor.setSelectedBufferRange(expandState.prev.range)
       expandState = expandState.prev
-      editor = atom.workspace.getActiveTextEditor()
-      editor.setSelectedBufferRange(expandState.range)
 
 navigate = (fn) ->
   editor = atom.workspace.getActiveTextEditor()

--- a/spec/lisp-paredit-spec.coffee
+++ b/spec/lisp-paredit-spec.coffee
@@ -88,6 +88,10 @@ describe "LispParedit", ->
     testCommand "expand-selection",     "(a (<b> c) d)",        "(a (<b c>) d)"
     testCommand "expand-selection",     "(a (<b>\n c) d)",      "(a (<b\n c>) d)"
 
+    testCommand "contract-selection",   "(a (<b\n c>) d)",      "(a (<b>\n c) d)"
+    testCommand "contract-selection",   "(a (<b c>) d)",        "(a (<b> c) d)"
+    testCommand "contract-selection",   "(a (<b> c) d)",        "(a (b| c) d)"
+
     testCommand "delete-backwards",     "(a b c|)",             "(a b |)"
     testCommand "delete-backwards",     "(a| b| c|)",           "(| | |)"
     testCommand "delete-backwards",     "(|)",                  "|"


### PR DESCRIPTION
Hey there @jonspalding! First off, thanks a ton for your work on this package, I'm finding it super useful while learning Lisp.

I wanted to add a feature from paredit-js that's missing currently for this Atom package: the `contract-selection` shortcut. 

Its implementation is similar to that of paredit-js, where a list of the expansion history is kept so that contractions are simply undos on that timeline.

Let me know if you need any clarification!